### PR TITLE
Add GNOME Shell 50 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A lightweight GNOME extension that lets you take a peek at your desktop. Click a
 
 
 # GNOME Compatibility
-Tested & works on GNOME 48 and 49.
+Tested & works on GNOME 48, 49, and 50.
 
 # Compatibility with other extensions
 Works with similar extensions like Show Desktop Button, but with some possible limits:

--- a/extension.js
+++ b/extension.js
@@ -1,4 +1,4 @@
-//gnome 48+49 code
+//gnome 48+49+50 code
 import Clutter from 'gi://Clutter';
 import Meta from 'gi://Meta';
 import Shell from 'gi://Shell';

--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "uuid": "easy-peek@Markerto",
   "name": "EasyPeek",
   "description": "A lightweight extension that lets you take a peek at your desktop. Click anywhere on the desktop to minimize or reveal all windows.",
-  "shell-version": ["49"],
-  "version": 5,
+  "shell-version": ["49", "50"],
+  "version": 6,
   "url": "https://github.com/Markerto/gnome-EasyPeek/"
 }


### PR DESCRIPTION
## What changed

- Add GNOME Shell 50 to the supported shell versions.
- Bump the extension version from 5 to 6.
- Update the compatibility documentation.

## Why

The official GNOME Shell 50 porting guide reports no required runtime changes for this extension API surface. The extension does not use the GNOME 50 APIs removed from the shell, so this update exposes the existing compatible code to GNOME 50 users.

## Validation

- Tested package creation with GNOME Shell 50.3's `gnome-extensions pack`.
- Passed `git diff --check`.
- Passed JavaScript syntax validation with `node --check extension.js`.
